### PR TITLE
Fix unprocessable entity error when versions are present

### DIFF
--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -50,8 +50,8 @@ class GithubCheckRunService
       output: {
         title: CHECK_NAME,
         summary: @summary,
-        annotations: (@annotations if @conclusion == "failure"),
-      }.compact
+        annotations: @annotations,
+      }
     )
   end
 end

--- a/lib/report_adapter.rb
+++ b/lib/report_adapter.rb
@@ -44,6 +44,7 @@ class ReportAdapter
           )
         end
       end
+      annotation_list
     end
 
     private


### PR DESCRIPTION
# Bug Fix

## Description

We were not actually sending GitHub our list of annotations, but rather the entire report generated from rubocop --format json. This caused there to be empty offenses in the annotations we were trying to create, which the API rejected due to missing keys.

This change ensures that we actually send our annotation list, instead of the entire report.

Ports over the changes made to fix andrewmcodes/rubocop-linter-action#40

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
