### PR TITLE
Update incorrect project name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the following to your GitHub action workflow to use StandardRB Linter Action
 
 ```yaml
 - name: StandardRB Linter
-  uses: andrewmcodes/standardrb-linter-action@v0.0.2
+  uses: andrewmcodes/standardrb-action@v0.0.2
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
# Bug fix

## Description

Reference to stardardrb-linter-action is incorrect.

## Why should this be added

I initially copied the first line in the readme a few weeks ago and gave up when it didn't work. I didn't notice the project name was wrong and just thought the action was broken. I decided to try again today and it works with the correct name.

## Checklist

- [x] My change is so simple that I just want an extra box to check.