### PR TITLE
Upgrade Ruby version to 3.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:2.6.5-alpine
+FROM ruby:alpine3.18
 
-RUN apk add --update build-base git
+RUN apk add --update build-base
 
 COPY lib /action/lib
 COPY README.md LICENSE /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:alpine3.18
 
-RUN apk add --update build-base
+RUN apk add --update build-base git
 
 COPY lib /action/lib
 COPY README.md LICENSE /


### PR DESCRIPTION
We're getting errors using this action as the installed version of Ruby is 2.6 and current versions of standard (via the Rubocop dependency) require a Ruby version of 2.7+.

This PR updates the version of Ruby to 3.2.2