### PR TITLE
update Ruby image due to rubocop requiring >= 2.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5-alpine
+FROM ruby:2.7-alpine
 
 RUN apk add --update build-base git
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bug fix

## Description
### Current Github action run
```
ERROR:  Error installing standard:
	There are no versions of rubocop (~> 1.56.2) compatible with your Ruby & RubyGems. Maybe try installing an older version of the gem you're looking for?
	rubocop requires Ruby version >= 2.7.0. The current ruby version is 2.6.5.114.
```

# Summary of the fix
`rubocop` requires a newer version of Ruby to successfully bundle. I'm upgrading to the oldest version or Ruby to satisfy the requirement, but upgrading to Ruby 3 also works as well.

Fixes # (issue)
Point to Ruby `2.7`

## Why should this be added
Allow GitHub actions to successfully work

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Actions are passing
